### PR TITLE
Add a simple whitespace deletion from abbr-string 

### DIFF
--- a/js/bibtex.js
+++ b/js/bibtex.js
@@ -153,7 +153,7 @@ function generateBibTeXEntry(tabTitle, tabUrl, format)
 {
   var abbr, suffix, entry, result;
 
-  abbr = tabTitle.substring(0, 5);
+  abbr = tabTitle.split(' ').join('').substring(0, 5);
   suffix = Math.floor(Math.random() * 100);
   //create the entry
   entry = "@misc{" + lescape(abbr) + suffix.toString() + ":online,\n";


### PR DESCRIPTION
I added a simple whitespace deletion from the abbr-string because an error occured when I tried to paste the generated bibtex entry in BibDesk and it contained a whitespace in the abbr.

Awesome work though! The extension is very helpful to me!